### PR TITLE
프로필 업데이트 기능 개발

### DIFF
--- a/data/src/main/java/buy/coke/zet/data/api/UserApiService.kt
+++ b/data/src/main/java/buy/coke/zet/data/api/UserApiService.kt
@@ -1,10 +1,16 @@
 package buy.coke.zet.data.api
 
 import buy.coke.zet.data.dto.CommonResponseDto
+import buy.coke.zet.data.dto.updateprofile.UpdateProfileRequestDto
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.POST
 
 interface UserApiService {
     @DELETE("/api/users/profile")
     suspend fun delete(): Response<CommonResponseDto<Unit>>
+
+    @POST("/api/users/profile")
+    suspend fun updateProfile(@Body request: UpdateProfileRequestDto): Response<CommonResponseDto<Unit>>
 }

--- a/data/src/main/java/buy/coke/zet/data/datasource/UserDataSource.kt
+++ b/data/src/main/java/buy/coke/zet/data/datasource/UserDataSource.kt
@@ -1,6 +1,7 @@
 package buy.coke.zet.data.datasource
 
 import buy.coke.zet.data.api.UserApiService
+import buy.coke.zet.data.dto.updateprofile.UpdateProfileRequestDto
 import buy.coke.zet.data.errorhandle.safeApiCallAllowingNull
 import buy.coke.zet.data.mapper.mapToUnit
 import buy.coke.zet.domain.ServiceResult
@@ -8,6 +9,7 @@ import javax.inject.Inject
 
 interface UserDataSource {
     suspend fun delete(): ServiceResult<Unit>
+    suspend fun updateProfile(updateProfile: UpdateProfileRequestDto): ServiceResult<Unit>
 }
 
 class UserDataSourceImpl @Inject constructor(
@@ -15,5 +17,9 @@ class UserDataSourceImpl @Inject constructor(
 ) : UserDataSource {
     override suspend fun delete(): ServiceResult<Unit> {
         return safeApiCallAllowingNull { apiService.delete() }.mapToUnit()
+    }
+
+    override suspend fun updateProfile(updateProfile: UpdateProfileRequestDto): ServiceResult<Unit> {
+        return safeApiCallAllowingNull { apiService.updateProfile(updateProfile) }.mapToUnit()
     }
 }

--- a/data/src/main/java/buy/coke/zet/data/dto/updateprofile/UpdateProfileRequestDto.kt
+++ b/data/src/main/java/buy/coke/zet/data/dto/updateprofile/UpdateProfileRequestDto.kt
@@ -1,0 +1,9 @@
+package buy.coke.zet.data.dto.updateprofile
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateProfileRequestDto(
+    @SerializedName("nickname") val nickname: String? = null,
+    @SerializedName("commerceIds") val commerceIds: List<Long>? = null,
+    @SerializedName("cardCompanyIds") val cardCompanyIds: List<Long>? = null
+)

--- a/data/src/main/java/buy/coke/zet/data/mapper/Mapper.kt
+++ b/data/src/main/java/buy/coke/zet/data/mapper/Mapper.kt
@@ -1,7 +1,9 @@
 package buy.coke.zet.data.mapper
 
 import buy.coke.zet.data.dto.login.LoginResponseDto
+import buy.coke.zet.data.dto.updateprofile.UpdateProfileRequestDto
 import buy.coke.zet.domain.entitiy.response.LoginResponseEntity
+import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
 
 fun LoginResponseDto.toEntity(): LoginResponseEntity {
     return LoginResponseEntity(
@@ -9,5 +11,13 @@ fun LoginResponseDto.toEntity(): LoginResponseEntity {
         email = this.user?.email,
         nickname = this.user?.nickname,
         newUser = newUser
+    )
+}
+
+fun UpdateProfileRequestEntity.toDto(): UpdateProfileRequestDto {
+    return UpdateProfileRequestDto(
+        nickname = this.nickname,
+        commerceIds = this.commerceIds,
+        cardCompanyIds = this.cardCompanyIds
     )
 }

--- a/data/src/main/java/buy/coke/zet/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/buy/coke/zet/data/repository/UserRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package buy.coke.zet.data.repository
 
 import buy.coke.zet.data.datasource.UserDataSource
+import buy.coke.zet.data.mapper.toDto
 import buy.coke.zet.domain.ServiceResult
+import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
 import buy.coke.zet.domain.repository.UserRepository
 import javax.inject.Inject
 
@@ -11,6 +13,15 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun delete(): ServiceResult<Unit> {
         val result = userDataSource.delete()
         return when(result) {
+            is ServiceResult.Success -> ServiceResult.Success(Unit)
+            is ServiceResult.Error -> ServiceResult.Error(result.code, result.message)
+            is ServiceResult.NetworkError -> ServiceResult.NetworkError
+        }
+    }
+
+    override suspend fun updateProfile(updateProfile: UpdateProfileRequestEntity): ServiceResult<Unit> {
+        val result = userDataSource.updateProfile(updateProfile.toDto())
+        return when (result) {
             is ServiceResult.Success -> ServiceResult.Success(Unit)
             is ServiceResult.Error -> ServiceResult.Error(result.code, result.message)
             is ServiceResult.NetworkError -> ServiceResult.NetworkError

--- a/domain/src/main/java/buy/coke/zet/domain/entitiy/updateprofile/UpdateProfileRequestEntity.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/entitiy/updateprofile/UpdateProfileRequestEntity.kt
@@ -1,0 +1,7 @@
+package buy.coke.zet.domain.entitiy.updateprofile
+
+data class UpdateProfileRequestEntity(
+    val nickname: String? = null,
+    val commerceIds: List<Long>? = null,
+    val cardCompanyIds: List<Long>? = null
+)

--- a/domain/src/main/java/buy/coke/zet/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/repository/UserRepository.kt
@@ -1,7 +1,9 @@
 package buy.coke.zet.domain.repository
 
 import buy.coke.zet.domain.ServiceResult
+import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
 
 interface UserRepository {
     suspend fun delete(): ServiceResult<Unit>
+    suspend fun updateProfile(updateProfile: UpdateProfileRequestEntity): ServiceResult<Unit>
 }

--- a/domain/src/main/java/buy/coke/zet/domain/usecase/UpdateProfileUseCase.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/usecase/UpdateProfileUseCase.kt
@@ -5,6 +5,15 @@ import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
 import buy.coke.zet.domain.repository.UserRepository
 import javax.inject.Inject
 
+/** 사용자 프로필 업데이트 유스케이스
+ * UpdateProfileRequestEntity의
+ * nickname = 사용자 닉네임
+ * commerceIds = 쇼핑몰 아이디
+ * cardCompanyIds = 카드사 아이디
+ * 각 아이디는 백엔드에서 정의하면 카톡 또는 해당 주석에 다시 달아놓겠습니다.
+ * 테스트용으로 commerceIds = 1, cardCompanyIds = 1 하시면 테스트 가능하십니다.
+ */
+
 class UpdateProfileUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {

--- a/domain/src/main/java/buy/coke/zet/domain/usecase/UpdateProfileUseCase.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/usecase/UpdateProfileUseCase.kt
@@ -1,0 +1,14 @@
+package buy.coke.zet.domain.usecase
+
+import buy.coke.zet.domain.ServiceResult
+import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
+import buy.coke.zet.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UpdateProfileUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(updateProfile: UpdateProfileRequestEntity): ServiceResult<Unit> {
+        return userRepository.updateProfile(updateProfile)
+    }
+}


### PR DESCRIPTION
# 🤷‍♂️ Description

- 최초 로그인시 프로필 업데이트 기능 개발 했습니다.
- UpdateProfileRequestEntity의 commerceIds(쇼핑몰)와 cardCompanyIds(카드사)가 명세서에 아직 정의가 안되어있습니다.
 테스트용으로 commerceIds에 1, cardCompanyIds에 1을 넣으시면 테스트용 값이 적용됩니다.
Swagger에 각 값을 백엔드에서 명시해주시면 카톡, 또는 이 PR이 머지가 안된다면 UseCase에 명시해두겠습니다.

resolved: #34 