### PR TITLE
회원탈퇴 로직및 LoginStatus 리팩토링

### DIFF
--- a/data/src/main/java/buy/coke/zet/data/api/UserApiService.kt
+++ b/data/src/main/java/buy/coke/zet/data/api/UserApiService.kt
@@ -1,19 +1,19 @@
 package buy.coke.zet.data.api
 
 import buy.coke.zet.data.dto.CommonResponseDto
+import buy.coke.zet.data.dto.delete.DeleteRequestDto
 import buy.coke.zet.data.dto.getprofile.GetProfileResponseDto
 import buy.coke.zet.data.dto.updateprofile.UpdateProfileRequestDto
 import buy.coke.zet.data.dto.updateprofile.UpdateProfileResponseDto
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
-import retrofit2.http.POST
 
 interface UserApiService {
-    @DELETE("/api/users/profile")
-    suspend fun delete(): Response<CommonResponseDto<Unit>>
+    @HTTP(method = "DELETE", path = "/api/users/profile", hasBody = true)
+    suspend fun delete(@Body request: DeleteRequestDto): Response<CommonResponseDto<Unit>>
 
     @PATCH("/api/users/profile")
     suspend fun updateProfile(@Body request: UpdateProfileRequestDto): Response<CommonResponseDto<UpdateProfileResponseDto>>

--- a/data/src/main/java/buy/coke/zet/data/datasource/UserDataSource.kt
+++ b/data/src/main/java/buy/coke/zet/data/datasource/UserDataSource.kt
@@ -1,6 +1,7 @@
 package buy.coke.zet.data.datasource
 
 import buy.coke.zet.data.api.UserApiService
+import buy.coke.zet.data.dto.delete.DeleteRequestDto
 import buy.coke.zet.data.dto.getprofile.GetProfileResponseDto
 import buy.coke.zet.data.dto.updateprofile.UpdateProfileRequestDto
 import buy.coke.zet.data.dto.updateprofile.UpdateProfileResponseDto
@@ -11,7 +12,7 @@ import buy.coke.zet.domain.ServiceResult
 import javax.inject.Inject
 
 interface UserDataSource {
-    suspend fun delete(): ServiceResult<Unit>
+    suspend fun delete(request: DeleteRequestDto): ServiceResult<Unit>
     suspend fun updateProfile(updateProfile: UpdateProfileRequestDto): ServiceResult<UpdateProfileResponseDto>
     suspend fun getProfile(): ServiceResult<GetProfileResponseDto>
 }
@@ -19,8 +20,8 @@ interface UserDataSource {
 class UserDataSourceImpl @Inject constructor(
     private val apiService: UserApiService
 ) : UserDataSource {
-    override suspend fun delete(): ServiceResult<Unit> {
-        return safeApiCallAllowingNull { apiService.delete() }.mapToUnit()
+    override suspend fun delete(request: DeleteRequestDto): ServiceResult<Unit> {
+        return safeApiCallAllowingNull { apiService.delete(request) }.mapToUnit()
     }
 
     override suspend fun updateProfile(updateProfile: UpdateProfileRequestDto): ServiceResult<UpdateProfileResponseDto> {

--- a/data/src/main/java/buy/coke/zet/data/dto/delete/DeleteRequestDto.kt
+++ b/data/src/main/java/buy/coke/zet/data/dto/delete/DeleteRequestDto.kt
@@ -1,0 +1,8 @@
+package buy.coke.zet.data.dto.delete
+
+import com.google.gson.annotations.SerializedName
+
+data class DeleteRequestDto(
+    @SerializedName("socialProvider") val socialProvider: String? = "GOOGLE",
+    @SerializedName("revokeToken") val revokeToken: String?= null
+)

--- a/data/src/main/java/buy/coke/zet/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/buy/coke/zet/data/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package buy.coke.zet.data.repository
 
 import buy.coke.zet.data.datasource.UserDataSource
+import buy.coke.zet.data.dto.delete.DeleteRequestDto
 import buy.coke.zet.data.local.TokenManager
 import buy.coke.zet.data.mapper.toDto
 import buy.coke.zet.data.mapper.toEntity
@@ -15,8 +16,8 @@ class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource,
     private val tokenManager: TokenManager
 ) : UserRepository {
-    override suspend fun delete(): ServiceResult<Unit> {
-        val result = userDataSource.delete()
+    override suspend fun delete(revokeToken: String): ServiceResult<Unit> {
+        val result = userDataSource.delete(DeleteRequestDto(revokeToken = revokeToken, socialProvider = USER_PROVIDER_GOOGLE))
         return when(result) {
             is ServiceResult.Success -> ServiceResult.Success(Unit)
             is ServiceResult.Error -> ServiceResult.Error(result.code, result.message)
@@ -56,5 +57,9 @@ class UserRepositoryImpl @Inject constructor(
             is ServiceResult.Error -> ServiceResult.Error(result.code, result.message)
             is ServiceResult.NetworkError -> ServiceResult.NetworkError
         }
+    }
+
+    companion object {
+        private const val USER_PROVIDER_GOOGLE = "GOOGLE"
     }
 }

--- a/domain/src/main/java/buy/coke/zet/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/repository/UserRepository.kt
@@ -6,7 +6,7 @@ import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileRequestEntity
 import buy.coke.zet.domain.entitiy.updateprofile.UpdateProfileResponseEntity
 
 interface UserRepository {
-    suspend fun delete(): ServiceResult<Unit>
+    suspend fun delete(revokeToken: String): ServiceResult<Unit>
     suspend fun updateProfile(updateProfile: UpdateProfileRequestEntity): ServiceResult<UpdateProfileResponseEntity>
     suspend fun isValidToken(hasToken: Boolean): ServiceResult<GetProfileResponseEntity>
     suspend fun isHasToken(): Boolean

--- a/domain/src/main/java/buy/coke/zet/domain/usecase/DeleteUseCase.kt
+++ b/domain/src/main/java/buy/coke/zet/domain/usecase/DeleteUseCase.kt
@@ -5,13 +5,13 @@ import buy.coke.zet.domain.repository.UserRepository
 import javax.inject.Inject
 
 /** 회원탈퇴 유스케이스
- * 바로 호출해서 사용하시면 됩니다.
+ * revokeToken을 호출해 사용하시면 됩니다.
  */
 
 class DeleteUseCase @Inject constructor(
     private val userRepository: UserRepository
 ){
-    suspend operator fun invoke(): ServiceResult<Unit> {
-        return userRepository.delete()
+    suspend operator fun invoke(revokeToken: String): ServiceResult<Unit> {
+        return userRepository.delete(revokeToken)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ mockito = "5.1.0"
 kotlinxCoroutinesTest = "1.7.2"
 paging = "3.3.4"
 viewpager2 = "1.1.0"
+playServicesAuth = "21.3.0"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
@@ -85,6 +86,9 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 # Paging https://developer.android.com/topic/libraries/architecture/paging/v3-overview?hl=ko
 paging = { group = "androidx.paging", name = "paging-runtime-ktx", version.ref = "paging" }
 paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
+
+# https://developers.google.com/android/guides/setup?hl=ko
+play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -14,6 +14,7 @@ if (localPropertiesFile.exists()) {
 }
 
 val GOOGLE_CLIENT_ID = localProperties.getProperty("GOOGLE_CLIENT_ID", "")
+val GOOGLE_SECRET_PWD = localProperties.getProperty("GOOGLE_SECRET_PWD", "")
 
 android {
     namespace = "buy.coke.zet.presentation"
@@ -26,6 +27,7 @@ android {
         consumerProguardFiles("consumer-rules.pro")
 
         buildConfigField("String", "GOOGLE_CLIENT_ID", "\"$GOOGLE_CLIENT_ID\"")
+        buildConfigField("String", "GOOGLE_SECRET_PWD", "\"$GOOGLE_SECRET_PWD\"")
     }
 
     buildTypes {
@@ -63,6 +65,8 @@ dependencies {
     implementation(libs.identity.googleid)
     implementation(libs.androidx.viewpager2)
     implementation(libs.balloon)
+    implementation(libs.play.services.auth)
+    implementation(libs.okhttp)
 
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.core.ktx)

--- a/presentation/src/main/java/buy/coke/zet/presentation/LoginStatus.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/LoginStatus.kt
@@ -1,7 +1,0 @@
-package buy.coke.zet.presentation
-
-import buy.coke.zet.domain.entitiy.login.LoginResponseEntity
-
-object LoginStatus {
-    var userInfo: LoginResponseEntity? = null
-}

--- a/presentation/src/main/java/buy/coke/zet/presentation/info/mypage/MyPageActivity.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/info/mypage/MyPageActivity.kt
@@ -1,8 +1,12 @@
 package buy.coke.zet.presentation.info.mypage
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -17,6 +21,7 @@ import buy.coke.zet.presentation.info.notification_setting.NotificationSettingAc
 import buy.coke.zet.presentation.info.term.TERM_TITLE
 import buy.coke.zet.presentation.info.term.TermActivity
 import buy.coke.zet.presentation.intro.signup.SignUpActivity
+import buy.coke.zet.presentation.util.GoogleDeleteManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,6 +31,24 @@ class MyPageActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMyPageBinding
     @Inject lateinit var logoutUseCase: LogoutUseCase
     @Inject lateinit var deleteUseCase: DeleteUseCase
+
+    private val signInLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val authCode = GoogleDeleteManager.extractAuthCode(result.data)
+        if (authCode != null) {
+            lifecycleScope.launch {
+                val accessToken = GoogleDeleteManager.getAccessToken(authCode)
+                if (accessToken != null) {
+                    deleteUseCase(accessToken)
+                } else {
+                    Toast.makeText(this@MyPageActivity, "Google에서 AccessToken 받아오기 실패", Toast.LENGTH_SHORT).show()
+                }
+            }
+        } else {
+            Toast.makeText(this@MyPageActivity, "Google에서 AccessToken 받아오기 실패", Toast.LENGTH_SHORT).show()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -68,7 +91,8 @@ class MyPageActivity : AppCompatActivity() {
                 warning = getString(R.string.withdraw_warning),
                 yesButtonListener = {
                     lifecycleScope.launch {
-                        deleteUseCase()
+                        val intent = GoogleDeleteManager.getSignInIntent(Activity())
+                        signInLauncher.launch(intent)
                         finishAffinity()
                     }
                 }

--- a/presentation/src/main/java/buy/coke/zet/presentation/info/mypage/MyPageActivity.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/info/mypage/MyPageActivity.kt
@@ -2,9 +2,6 @@ package buy.coke.zet.presentation.info.mypage
 
 import android.content.Intent
 import android.os.Bundle
-import android.text.Spannable
-import android.text.SpannableString
-import android.text.style.ForegroundColorSpan
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -12,7 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import buy.coke.zet.common.designsystem.dialog.LongDialog
 import buy.coke.zet.domain.usecase.DeleteUseCase
 import buy.coke.zet.domain.usecase.LogoutUseCase
-import buy.coke.zet.presentation.LoginStatus
+import buy.coke.zet.presentation.model.LoginStatus
 import buy.coke.zet.presentation.R
 import buy.coke.zet.presentation.databinding.ActivityMyPageBinding
 import buy.coke.zet.presentation.info.announcement.AnnouncementActivity
@@ -21,7 +18,6 @@ import buy.coke.zet.presentation.info.term.TERM_TITLE
 import buy.coke.zet.presentation.info.term.TermActivity
 import buy.coke.zet.presentation.intro.signup.SignUpActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/presentation/src/main/java/buy/coke/zet/presentation/intro/signup/SignUpActivity.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/intro/signup/SignUpActivity.kt
@@ -2,22 +2,19 @@ package buy.coke.zet.presentation.intro.signup
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
-import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import buy.coke.zet.domain.ServiceResult
 import buy.coke.zet.domain.usecase.LoginWithGoogleUseCase
-import buy.coke.zet.presentation.LoginStatus
+import buy.coke.zet.presentation.model.LoginStatus
 import buy.coke.zet.presentation.R
 import buy.coke.zet.presentation.databinding.ActivitySignUpBinding
-import buy.coke.zet.presentation.intro.entry.EntryActivity
+import buy.coke.zet.presentation.model.toUserInfo
 import buy.coke.zet.presentation.setting.NicknameSettingActivity
 import buy.coke.zet.presentation.util.GoogleAuthManager
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,7 +37,7 @@ class SignUpActivity : AppCompatActivity() {
             GoogleAuthManager.getGoogleToken(this@SignUpActivity)?.let { token ->
                 loginWithGoogleUseCase(token).also { result ->
                     if (result is ServiceResult.Success) {
-                        LoginStatus.userInfo = result.data
+                        LoginStatus.userInfo = result.data.toUserInfo()
                         Toast.makeText(this@SignUpActivity, getString(R.string.login_success), Toast.LENGTH_SHORT).show()
                     }
                     else {

--- a/presentation/src/main/java/buy/coke/zet/presentation/intro/splash/SplashActivity.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/intro/splash/SplashActivity.kt
@@ -10,11 +10,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import buy.coke.zet.domain.ServiceResult
-import buy.coke.zet.domain.entitiy.login.LoginResponseEntity
-import buy.coke.zet.presentation.LoginStatus
 import buy.coke.zet.presentation.R
 import buy.coke.zet.presentation.databinding.ActivitySplashBinding
 import buy.coke.zet.presentation.intro.signup.SignUpActivity
+import buy.coke.zet.presentation.model.LoginStatus
+import buy.coke.zet.presentation.model.toUserInfo
 import buy.coke.zet.presentation.product.list.ProductListActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -33,7 +33,7 @@ class SplashActivity : AppCompatActivity() {
 
             if (autoLoginResult is ServiceResult.Success) {
                 Toast.makeText(this@SplashActivity, "로그인 성공", Toast.LENGTH_SHORT).show()
-//                LoginStatus.userInfo = autoLoginResult.data
+                LoginStatus.userInfo = autoLoginResult.data.toUserInfo()
                 
                 Handler(Looper.getMainLooper()).postDelayed({
                     startActivity(Intent(this@SplashActivity, ProductListActivity::class.java))

--- a/presentation/src/main/java/buy/coke/zet/presentation/model/LoginStatus.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/model/LoginStatus.kt
@@ -1,0 +1,5 @@
+package buy.coke.zet.presentation.model
+
+object LoginStatus {
+    var userInfo: UserInfo? = null
+}

--- a/presentation/src/main/java/buy/coke/zet/presentation/model/UserInfo.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/model/UserInfo.kt
@@ -1,0 +1,33 @@
+package buy.coke.zet.presentation.model
+
+import buy.coke.zet.domain.entitiy.getprofile.GetProfileResponseEntity
+import buy.coke.zet.domain.entitiy.login.LoginResponseEntity
+
+data class UserInfo(
+    val email: String,
+    val nickname: String,
+    val commerceNames: List<String> = emptyList(),
+    val notificationEnabled: Boolean = false,
+    val receiveNotificationAfter8PM: Boolean = false,
+    val id: Long? = null,
+    val newUser: Boolean? = null
+)
+
+fun LoginResponseEntity.toUserInfo(): UserInfo {
+    return UserInfo(
+        email = this.email.orEmpty(),
+        nickname = this.nickname.orEmpty(),
+        id = this.id,
+        newUser = this.newUser
+    )
+}
+
+fun GetProfileResponseEntity.toUserInfo(): UserInfo {
+    return UserInfo(
+        email = this.email.orEmpty(),
+        nickname = this.nickname.orEmpty(),
+        commerceNames = this.commerceNames,
+        notificationEnabled = this.notificationEnabled,
+        receiveNotificationAfter8PM = this.receiveNotificationAfter8PM
+    )
+}

--- a/presentation/src/main/java/buy/coke/zet/presentation/product/list/ProductListActivity.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/product/list/ProductListActivity.kt
@@ -6,7 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
-import buy.coke.zet.presentation.LoginStatus
+import buy.coke.zet.presentation.model.LoginStatus
 import buy.coke.zet.presentation.R
 import buy.coke.zet.presentation.databinding.ActivityProductListBinding
 import buy.coke.zet.presentation.info.mypage.MyPageActivity

--- a/presentation/src/main/java/buy/coke/zet/presentation/util/GoogleAuthManager.kt
+++ b/presentation/src/main/java/buy/coke/zet/presentation/util/GoogleAuthManager.kt
@@ -1,11 +1,21 @@
 package buy.coke.zet.presentation.util
 
 import android.app.Activity
+import android.content.Intent
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import buy.coke.zet.presentation.BuildConfig
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.ApiException
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
 import java.security.MessageDigest
 import java.util.UUID
 
@@ -43,5 +53,58 @@ object GoogleAuthManager {
         return MessageDigest.getInstance("SHA-256")
             .digest(nonce.toByteArray())
             .joinToString("") { "%02x".format(it) }
+    }
+}
+
+/** 구글 revoke, 완전한 회원탈퇴를 위한 Manager
+ * 완전한 회원탈퇴를 위해 AccessToken을 해당 메서드로 받아옵니다.
+ * */
+
+object GoogleDeleteManager {
+    private const val CLIENT_ID = BuildConfig.GOOGLE_CLIENT_ID
+    private const val CLIENT_SECRET = BuildConfig.GOOGLE_SECRET_PWD
+    private const val REDIRECT_URI = ""
+
+    fun getSignInIntent(activity: Activity): Intent {
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestServerAuthCode(CLIENT_ID, true)
+            .build()
+
+        return GoogleSignIn.getClient(activity, gso).signInIntent
+    }
+
+    fun extractAuthCode(data: Intent?): String? {
+        val task = GoogleSignIn.getSignedInAccountFromIntent(data)
+        return try {
+            task.getResult(ApiException::class.java)?.serverAuthCode
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun getAccessToken(authCode: String): String? = withContext(Dispatchers.IO) {
+        val url = "https://oauth2.googleapis.com/token"
+
+        val formBody = FormBody.Builder()
+            .add("code", authCode)
+            .add("client_id", CLIENT_ID)
+            .add("client_secret", CLIENT_SECRET)
+            .add("redirect_uri", REDIRECT_URI)
+            .add("grant_type", "authorization_code")
+            .build()
+
+        val request = Request.Builder()
+            .url(url)
+            .post(formBody)
+            .build()
+
+        val client = OkHttpClient()
+        val response = client.newCall(request).execute()
+
+        if (response.isSuccessful) {
+            val body = response.body?.string()
+            JSONObject(body ?: "").getString("access_token")
+        } else null
     }
 }


### PR DESCRIPTION
# 🤷‍♂️ Description

### 1. LoginStatus를 리팩토링 하였습니다.
SplashActivity에서 주석 처리 되었던 부분을 해제하고 LoginStatus가 GetProfileResponseEntity만 받아오던것을 UserInfo로 통합해 놨습니다. 이제 정상 작동합니다.

이후에 리팩토링 하셔서 sealed class 같은것으로 UiState를 관리하시면 더욱 편하고 좋을듯 합니다.
또, Inject로 UseCase를 Activity로 받아오는것이 좋지 못하다고 생각합니다. 
configuration change가 발생했을때 대처도 어려울듯 하여 ViewModel에서 UseCase를 받아오는것이 어떠한가 싶습니다.

[ 아래는 기존 LoginStauts를 임시로 실행되게끔 처리한 코드입니다. ]
<img width="500" height="550" alt="userinfo" src="https://github.com/user-attachments/assets/87842fb2-d19c-4fe9-abc0-9f69baaa5b01" />
<img width="344" height="89" alt="loginstatus" src="https://github.com/user-attachments/assets/43472ad0-b25d-414a-b1a5-e5e0f9a11b46" />


### 2. 회원탈퇴 로직을 리팩토링 했습니다.
백엔드 필드 변경에따라 회원탈퇴 로직을 리팩토링했습니다.
무엇보다 현재 백단에서 회원탈퇴시 revoke 요청을 위해 GoogleOAtuh AccessToken이 필요하셔서
회원탈퇴시 재로그인을 시키는 방향으로 리팩토링 진행했습니다.

# 📸 Screenshots


# 📖 Reference

<!-- 필요한 경우 레퍼런스을 넣어 주세요. -->

# ✳️ Remarks
<!-- 비고란으로 Optional 입니다. 필요시 수정해주세요. -->

resolved: #59 